### PR TITLE
docs: deprecate giter8 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A [Giter8][g8] template for the Gatling performance test project.
 
+> Deprecated: use the Galaxio CLI template instead.
+>
+> ```shell
+> go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest
+> galaxio template init gatling/scala-sbt
+> ```
+>
+> New development lives in `galax-io/templates-gatling`; this Giter8 template is
+> kept for existing users only.
+
 # About
 
 The Gatling-template.g8 is a handy tool that allows you to quickly create SBTs for Gatling. The template allows you to

--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,5 +1,15 @@
 # Gatling Template Project
 
+> Deprecated: use the Galaxio CLI template instead.
+>
+> ```shell
+> go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest
+> galaxio template init gatling/scala-sbt
+> ```
+>
+> New development lives in `galax-io/templates-gatling`; this Giter8 template is
+> kept for existing users only.
+
 Template project for Gatling performance tests
 
 ## Project structure


### PR DESCRIPTION
## Summary
- mark Giter8 template deprecated
- point users to `galaxio template init gatling/scala-sbt`
- keep repo positioned for existing users only

## Test
- docs only